### PR TITLE
chore: Update go module path

### DIFF
--- a/collector/client.go
+++ b/collector/client.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/boynux/squid-exporter/types"
+	"github.com/konflux-ci/squid-exporter/types"
 )
 
 // CacheObjectClient holds information about Squid manager.

--- a/collector/client_test.go
+++ b/collector/client_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/boynux/squid-exporter/types"
+	"github.com/konflux-ci/squid-exporter/types"
 )
 
 func TestReadFromSquid(t *testing.T) {

--- a/collector/metrics.go
+++ b/collector/metrics.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/boynux/squid-exporter/config"
+	"github.com/konflux-ci/squid-exporter/config"
 )
 
 type descMap map[string]*prometheus.Desc

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/boynux/squid-exporter
+module github.com/konflux-ci/squid-exporter
 
 go 1.20
 

--- a/helpers.go
+++ b/helpers.go
@@ -8,7 +8,7 @@ import (
 
 	proxyproto "github.com/pires/go-proxyproto"
 
-	"github.com/boynux/squid-exporter/config"
+	"github.com/konflux-ci/squid-exporter/config"
 )
 
 func createProxyHeader(cfg *config.Config) string {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/boynux/squid-exporter/config"
+	"github.com/konflux-ci/squid-exporter/config"
 )
 
 func TestCreatProxyHelper(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -16,8 +16,8 @@ import (
 	"github.com/prometheus/common/version"
 	"github.com/prometheus/exporter-toolkit/web"
 
-	"github.com/boynux/squid-exporter/collector"
-	"github.com/boynux/squid-exporter/config"
+	"github.com/konflux-ci/squid-exporter/collector"
+	"github.com/konflux-ci/squid-exporter/config"
 )
 
 func init() {


### PR DESCRIPTION
Update go module path so this repo can be used as
go dependency in other repositories.

Jira-Url: https://issues.redhat.com/browse/KFLUXVNGD-434